### PR TITLE
Name the `ada` command in the package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,19 @@ Home: https://github.com/krande/adapy
 
 Package license: GPL-3.0-or-later
 
-Summary: A python library for structural analysis and design
+Summary: A python library for structural analysis and design, plus the `ada` command-line tool
 
 Documentation: https://krande.github.io/adapy/
+
+ADAPY is a python library for structural analysis and design. It reads and
+writes common CAD and FEM formats and can build, visualise and run analyses
+on structural models.
+
+Installing this package also provides the `ada` command-line tool. Run
+`ada --help` for the full list of subcommands; these include `ada convert`
+(convert between supported CAD/FEM formats), `ada view` (open a model in
+the built-in web viewer) and `ada serve` (run the REST API or worker
+process).
 
 About ada-py-core
 -----------------
@@ -22,11 +32,14 @@ Home: https://github.com/krande/adapy
 
 Package license: GPL-3.0-or-later
 
-Summary: A python library for structural analysis and design
+Summary: A python library for structural analysis and design, plus the `ada` command-line tool
 
 Documentation: https://krande.github.io/adapy/
 
 The core package without dependencies of ADAPY, a python library for structural analysis and design.
+
+This output ships the `ada` command-line entry point; most of its
+subcommands need the full `ada-py` package to be installed as well.
 
 Current build status
 ====================

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 70f84cd69c2fa5c669bfcdb35cac58d9256d30d733e467e3cb4f8575a8fa167a
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:
@@ -35,6 +35,9 @@ outputs:
     about:
       description: |
         The core package without dependencies of ADAPY, a python library for structural analysis and design.
+
+        This output ships the `ada` command-line entry point; most of its
+        subcommands need the full `ada-py` package to be installed as well.
 
   - package:
       name: ${{ name }}
@@ -103,7 +106,17 @@ outputs:
 about:
   license: GPL-3.0-or-later
   license_file: LICENSE
-  summary: A python library for structural analysis and design
+  summary: A python library for structural analysis and design, plus the `ada` command-line tool
+  description: |
+    ADAPY is a python library for structural analysis and design. It reads and
+    writes common CAD and FEM formats and can build, visualise and run analyses
+    on structural models.
+
+    Installing this package also provides the `ada` command-line tool. Run
+    `ada --help` for the full list of subcommands; these include `ada convert`
+    (convert between supported CAD/FEM formats), `ada view` (open a model in
+    the built-in web viewer) and `ada serve` (run the REST API or worker
+    process).
   homepage: https://github.com/krande/adapy
   documentation: https://krande.github.io/adapy/
 


### PR DESCRIPTION
The recipe declares the console entry point `ada = ada_cli.main:main` on the `ada-py-core` output, but nothing in the published metadata mentioned that a command ships at all. `about.summary` was `A python library for structural analysis and design`, which describes the library only, so `conda search ada-py --info` and the anaconda.org page gave no hint that installing this package puts an `ada` executable on `PATH`. Since the distribution is named `ada-py` while the command is `ada`, that is an easy gap to trip over.

This is a metadata-only change:

- `about.summary` now names the command alongside the library.
- Added an `about.description` that points at `ada --help` for the subcommand list, naming a few (`convert`, `view`, `serve`) rather than reproducing a full command reference.
- The `ada-py-core` output's existing `description` now notes that it is the output which actually ships the entry point, and that most subcommands need the full `ada-py` package installed too.
- Bumped `build.number` to 1 so the corrected metadata is actually built and published for 0.45.7.

Verified against the source the recipe points at: the 0.45.7 tarball's `sha256` matches the recipe, and its `pyproject.toml` declares exactly one `[project.scripts]` entry, `ada = "ada_cli.main:main"` (the only other entry point is a `paradoc.figure_sources` plugin hook, not a command).

No rerender: the variant set is unchanged and `.ci_support/linux_64_.yaml` carries neither the build number nor the prose, so rerendering would only add noise.

Validated locally with `rattler-build build --render-only`, which renders both outputs cleanly at `_1` (`ada-py-core-0.45.7-pyh4616a5c_1`, `ada-py-0.45.7-pyh669cd7c_1`) and confirms the new summary/description and the `ada` entry point on the rendered metadata.

Checklist:

- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (if the version is unchanged)
- [x] Reset the build number to `0` (if the version changed) — n/a, version unchanged
- [ ] Re-rendered with the latest `conda-smithy` — deliberately skipped, see above
- [x] Ensured the license file is being packaged
